### PR TITLE
fix:force cross-spawn@7.0.5 to address security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,5 +125,8 @@
       "require": "./dist/*.js",
       "default": "./dist/*.mjs"
     }
+  },
+  "resolutions": {
+    "cross-spawn": "7.0.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1364,10 +1364,10 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+cross-spawn@7.0.5, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.5.tgz#910aac880ff5243da96b728bc6521a5f6c2f2f82"
+  integrity sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"


### PR DESCRIPTION
## Summary

- Force upgrade to `cross-spawn@7.0.5` to address [Dependabot issue](https://github.com/openlayer-ai/openlayer-ts/security/dependabot/8).