### PR TITLE
fix(imports): update import paths for OpenlayerHandler and traceOpenAI to reflect new module structure

### DIFF
--- a/examples/langchain-callback-handler.ts
+++ b/examples/langchain-callback-handler.ts
@@ -1,5 +1,5 @@
 import { ChatOpenAI } from '@langchain/openai';
-import OpenlayerHandler from 'openlayer/src/lib/integrations/langchain-callback';
+import { OpenlayerHandler } from 'openlayer/lib/integrations/langchainCallback';
 
 // First, make sure you export your:
 // - OPENAI_API_KEY -- or the API key of the model you're using via LangChain

--- a/examples/multi-step-tracing.ts
+++ b/examples/multi-step-tracing.ts
@@ -1,6 +1,6 @@
 import OpenAI from 'openai';
-import traceOpenAI from 'openlayer/src/lib/integrations/openai-tracer';
-import trace from 'openlayer/src/lib/tracing/tracer';
+import { traceOpenAI } from 'openlayer/lib/integrations/openAiTracer';
+import trace from 'openlayer/lib/tracing/tracer';
 
 // First, make sure you export your:
 // - OPENAI_API_KEY -- or the API key of the model you're using

--- a/examples/openai-tracing.ts
+++ b/examples/openai-tracing.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai';
-import traceOpenAI from 'openlayer/src/lib/integrations/openai-tracer';
+import { traceOpenAI } from 'openlayer/lib/integrations/openAiTracer';
 
 // First, make sure you export your:
 // - OPENAI_API_KEY


### PR DESCRIPTION
## 🛠️ Fix: Update Import Paths for Handler and Tracer Modules

### Summary

This PR updates the import paths for `OpenlayerHandler` and `traceOpenAI` in the example files to reflect the new module structure introduced in the recent `integrations/` refactor.

### ✅ Changes Made

- Updated `OpenlayerHandler` import in `examples/langchain-callback-handler.ts`:
  - From:  
    `openlayer/src/lib/integrations/langchain-callback`
  - To:  
    `openlayer/lib/integrations/langchainCallback`

- Updated `traceOpenAI` import in `examples/multi-step-tracing.ts` and `examples/openai-tracing.ts`:
  - From:  
    `openlayer/src/lib/integrations/openai-tracer`
  - To:  
    `openlayer/lib/integrations/openAiTracer`

- Ensured all other tracer-related imports are consistent with the new folder layout:
  - `openlayer/lib/tracing/tracer`

### 📁 Motivation

These updates align the example code with the recent cleanup of the `integrations/` directory. This makes the module references clearer, flatter, and easier to navigate.
