### PR TITLE
fix(closes OPEN-11316): support @langchain/core v1 + LangGraph metadata mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-bedrock-agent-runtime": "^3.862.0",
-    "@langchain/community": "^0.3.59",
-    "@langchain/core": "^0.3.80",
-    "@langchain/langgraph": "^0.4.9",
     "commander": "^12.1.0",
     "openai": "^4.49.0",
     "performance-now": "^2.1.0",
@@ -39,10 +36,14 @@
   "devDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.111",
     "@arethetypeswrong/cli": "^0.17.0",
+    "@langchain/community": "^1.1.29",
+    "@langchain/core": "^1.1.49",
+    "@langchain/langgraph": "^1.4.2",
     "@swc/core": "^1.3.102",
     "@swc/jest": "^0.2.29",
     "@types/jest": "^29.4.0",
     "@types/node": "^20.17.6",
+    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "8.31.1",
     "@typescript-eslint/parser": "8.31.1",
     "eslint": "^9.39.1",
@@ -105,10 +106,22 @@
     }
   },
   "peerDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.111"
+    "@anthropic-ai/claude-agent-sdk": "^0.2.111",
+    "@langchain/community": ">=0.3.59 <2",
+    "@langchain/core": ">=0.3.80 <2",
+    "@langchain/langgraph": ">=0.4.9 <2"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/claude-agent-sdk": {
+      "optional": true
+    },
+    "@langchain/community": {
+      "optional": true
+    },
+    "@langchain/core": {
+      "optional": true
+    },
+    "@langchain/langgraph": {
       "optional": true
     }
   }

--- a/src/lib/integrations/langchainCallback.ts
+++ b/src/lib/integrations/langchainCallback.ts
@@ -2,19 +2,7 @@ import type { AgentAction, AgentFinish } from '@langchain/core/agents';
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
 import type { Document } from '@langchain/core/documents';
 import type { Serialized } from '@langchain/core/load/serializable';
-import {
-  AIMessage,
-  AIMessageChunk,
-  BaseMessage,
-  ChatMessage,
-  FunctionMessage,
-  HumanMessage,
-  SystemMessage,
-  ToolMessage,
-  type UsageMetadata,
-  type BaseMessageFields,
-  type MessageContent,
-} from '@langchain/core/messages';
+import type { BaseMessage, UsageMetadata, BaseMessageFields, MessageContent } from '@langchain/core/messages';
 import type { Generation, LLMResult } from '@langchain/core/outputs';
 import type { ChainValues } from '@langchain/core/utils/types';
 import { getCurrentStep, processAndUploadTrace } from '../tracing/tracer';
@@ -44,6 +32,91 @@ const PROVIDER_TO_STEP_NAME: Record<string, string> = {
 
 const LANGSMITH_HIDDEN_TAG = 'langsmith:hidden';
 
+/**
+ * The message-type discriminator returned by LangChain `BaseMessage` instances.
+ *
+ * @see https://github.com/langchain-ai/langchainjs
+ */
+type LangChainMessageType = 'human' | 'ai' | 'system' | 'tool' | 'function' | 'chat' | 'generic';
+
+/**
+ * Duck-typed view of a LangChain message.
+ *
+ * We deliberately avoid `instanceof` against `@langchain/core` classes. When a
+ * user application depends on a different major of `@langchain/core` than the
+ * one resolved for this package, npm/yarn installs two physical copies of the
+ * library. `instanceof` compares against the class identity of *this* copy, so
+ * message objects created by the application's copy fail every check and their
+ * content/usage silently falls into generic/empty branches (OPEN-11316).
+ *
+ * Instead we read the public `getType()` / internal `_getType()` discriminator
+ * and probe for well-known fields. These are stable across 0.3.x and 1.x and
+ * are immune to duplicate-copy identity mismatches.
+ */
+type DuckMessage = {
+  content?: BaseMessageFields['content'];
+  name?: string | undefined;
+  role?: string | undefined;
+  additional_kwargs?: BaseMessageFields['additional_kwargs'];
+  tool_calls?: unknown[] | undefined;
+  usage_metadata?: UsageMetadata | undefined;
+  response_metadata?: Record<string, any> | undefined;
+  getType?: () => string;
+  _getType?: () => string;
+};
+
+/**
+ * Returns true when `value` looks like a LangChain message regardless of which
+ * `@langchain/core` copy produced it. A message is anything exposing the
+ * `getType()` / `_getType()` discriminator.
+ */
+function isLangChainMessage(value: unknown): value is DuckMessage {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as DuckMessage;
+  return typeof candidate.getType === 'function' || typeof candidate._getType === 'function';
+}
+
+/**
+ * Resolves the duck-typed message type string ('human' | 'ai' | ...). Prefers
+ * the public `getType()` and falls back to the internal `_getType()`.
+ */
+function getMessageType(message: DuckMessage): LangChainMessageType {
+  let type: string | undefined;
+  if (typeof message.getType === 'function') {
+    type = message.getType();
+  } else if (typeof message._getType === 'function') {
+    type = message._getType();
+  }
+  switch (type) {
+    case 'human':
+    case 'ai':
+    case 'system':
+    case 'tool':
+    case 'function':
+    case 'chat':
+      return type;
+    default:
+      return 'generic';
+  }
+}
+
+/**
+ * Detects an AI/assistant message by its duck-typed surface: either it reports
+ * type 'ai', or it carries assistant-only fields (`usage_metadata`/`tool_calls`).
+ * This stays correct across duplicate `@langchain/core` copies.
+ */
+function isAIMessageLike(message: unknown): message is DuckMessage {
+  if (!isLangChainMessage(message)) {
+    return false;
+  }
+  if (getMessageType(message) === 'ai') {
+    return true;
+  }
+  return 'usage_metadata' in message || 'tool_calls' in message;
+}
+
 type OpenlayerPrompt = {
   name: string;
   version: number;
@@ -67,6 +140,13 @@ type ConstructorParams = {
   tags?: string[] | undefined;
   version?: string | undefined;
   traceMetadata?: Record<string, unknown> | undefined;
+  /**
+   * When true (the default), LangGraph's injected `metadata.thread_id` is mapped
+   * to the trace session whenever no explicit {@link ConstructorParams.sessionId}
+   * was provided, so LangGraph apps get sessions for free. An explicitly provided
+   * `sessionId` always wins and is never clobbered. Set to `false` to opt out.
+   */
+  mapThreadIdToSession?: boolean | undefined;
 };
 
 /**
@@ -78,6 +158,16 @@ type ConstructorParams = {
  * - Agents and Tools
  * - Retrievers
  * - Error handling and hierarchical tracking
+ *
+ * @remarks
+ * LangChain JS dispatches callbacks in the background and does **not** block on
+ * them by default. In serverless environments (AWS Lambda, Vercel, Cloudflare
+ * Workers) the function can return and the runtime freeze/terminate before the
+ * Openlayer trace finishes uploading, silently dropping traces. Always flush
+ * pending callbacks before the handler returns, e.g. by `await`-ing
+ * `awaitAllCallbacks()` from `@langchain/core/callbacks/promises` (and fully
+ * awaiting your chain's `.invoke()`). See the README "LangChain integration"
+ * section for an example. Note `@langchain/core` v1 requires Node.js 20+.
  *
  * @example
  * ```typescript
@@ -103,6 +193,9 @@ export class OpenlayerHandler extends BaseCallbackHandler {
   private sessionId?: string | undefined;
   private tags: string[];
   private traceMetadata?: Record<string, unknown> | undefined;
+  private readonly mapThreadIdToSession: boolean;
+  /** Whether `sessionId` was provided explicitly (so it must not be clobbered). */
+  private readonly hasExplicitSessionId: boolean;
 
   private completionStartTimes: Record<string, Date> = {};
   private promptToParentRunMap: Map<string, OpenlayerPrompt> = new Map();
@@ -118,10 +211,12 @@ export class OpenlayerHandler extends BaseCallbackHandler {
     super();
 
     this.sessionId = params?.sessionId;
+    this.hasExplicitSessionId = params?.sessionId != null;
     this.userId = params?.userId;
     this.tags = params?.tags ?? [];
     this.traceMetadata = params?.traceMetadata;
     this.version = params?.version;
+    this.mapThreadIdToSession = params?.mapThreadIdToSession ?? true;
   }
 
   // ============================================================================
@@ -234,11 +329,13 @@ export class OpenlayerHandler extends BaseCallbackHandler {
         }
       }
 
-      // Extract clean output for dashboard display
+      // Extract clean output for dashboard display. Use duck typing instead of
+      // `instanceof BaseMessage` so the message content is read even when the
+      // message comes from a different `@langchain/core` copy (OPEN-11316).
       const extractedOutput =
         lastResponse ?
-          'message' in lastResponse && lastResponse['message'] instanceof BaseMessage ?
-            lastResponse['message'].content // Just the content, not the full message object
+          'message' in lastResponse && isLangChainMessage((lastResponse as any)['message']) ?
+            (lastResponse as any)['message'].content // Just the content, not the full message object
           : lastResponse.text || ''
         : '';
 
@@ -310,7 +407,11 @@ export class OpenlayerHandler extends BaseCallbackHandler {
         return;
       }
 
-      const runName = name ?? chain.id.at(-1)?.toString() ?? 'Langchain Chain';
+      // Prefer an explicit name, then LangGraph's injected `metadata.langgraph_node`
+      // so graph nodes are identifiable instead of showing a generic chain name.
+      const langgraphNode =
+        typeof metadata?.['langgraph_node'] === 'string' ? (metadata['langgraph_node'] as string) : undefined;
+      const runName = name ?? langgraphNode ?? chain.id.at(-1)?.toString() ?? 'Langchain Chain';
 
       this.registerOpenlayerPrompt(parentRunId, metadata);
 
@@ -322,9 +423,9 @@ export class OpenlayerHandler extends BaseCallbackHandler {
         typeof inputs === 'object' &&
         'input' in inputs &&
         Array.isArray(inputs['input']) &&
-        inputs['input'].every((m) => m instanceof BaseMessage)
+        inputs['input'].every((m) => isLangChainMessage(m))
       ) {
-        finalInput = inputs['input'].map((m) => this.extractChatMessageContent(m));
+        finalInput = inputs['input'].map((m) => this.extractChatMessageContent(m as BaseMessage));
       } else if (typeof inputs === 'object' && 'content' in inputs && typeof inputs['content'] === 'string') {
         finalInput = inputs['content'];
       }
@@ -353,9 +454,11 @@ export class OpenlayerHandler extends BaseCallbackHandler {
         : undefined;
 
       let finalOutput: ChainValues | string | MessageContent = outputs;
-      if (step?.name === 'LangGraph' && lastMessage instanceof BaseMessage) {
-        // Surface the final assistant message as the trace output
-        finalOutput = lastMessage.content;
+      if (step?.name === 'LangGraph' && isLangChainMessage(lastMessage)) {
+        // Surface the final assistant message as the trace output. Duck-typed
+        // instead of `instanceof BaseMessage` so it works across duplicate
+        // `@langchain/core` copies (OPEN-11316).
+        finalOutput = lastMessage.content as MessageContent;
       } else if (
         typeof outputs === 'object' &&
         'output' in outputs &&
@@ -867,7 +970,10 @@ export class OpenlayerHandler extends BaseCallbackHandler {
 
   /** Recursively converts LangChain objects to a JSON-friendly format. */
   private convertLangchainObjects(obj: any): any {
-    if (obj instanceof BaseMessage) {
+    // Duck-typed message detection instead of `instanceof BaseMessage` so
+    // messages from a different `@langchain/core` copy are still converted
+    // (OPEN-11316).
+    if (isLangChainMessage(obj)) {
       return this.messageToDict(obj);
     }
 
@@ -896,15 +1002,19 @@ export class OpenlayerHandler extends BaseCallbackHandler {
   }
 
   /** Converts a LangChain message to a `{role, content}` dictionary. */
-  private messageToDict(message: BaseMessage): { role: string; content: MessageContent } {
-    const messageType = typeof message._getType === 'function' ? message._getType() : 'human';
+  private messageToDict(message: DuckMessage): { role: string; content: MessageContent } {
+    // Duck-typed discriminator (see getMessageType) instead of a direct
+    // `_getType()` call so the role resolves across duplicate `@langchain/core`
+    // copies (OPEN-11316).
+    const messageType = getMessageType(message);
 
     const role =
       messageType === 'human' ? 'user'
       : messageType === 'ai' ? 'assistant'
+      : messageType === 'generic' ? 'user'
       : messageType;
 
-    return { role, content: message.content };
+    return { role, content: (message.content ?? '') as MessageContent };
   }
 
   private registerOpenlayerPrompt(parentRunId?: string, metadata?: Record<string, unknown>): void {
@@ -927,6 +1037,24 @@ export class OpenlayerHandler extends BaseCallbackHandler {
     return azureRefusalError;
   }
 
+  /**
+   * Resolves the session id to attach to a step from the handler config and the
+   * LangChain callback `metadata`.
+   *
+   * An explicitly provided `sessionId` always wins. Otherwise, when
+   * {@link mapThreadIdToSession} is enabled, LangGraph's injected
+   * `metadata.thread_id` is used so LangGraph apps get sessions for free.
+   */
+  private resolveSessionId(metadata?: Record<string, unknown>): string | undefined {
+    if (this.hasExplicitSessionId) {
+      return this.sessionId;
+    }
+    if (this.mapThreadIdToSession && metadata && typeof metadata['thread_id'] === 'string') {
+      return metadata['thread_id'] as string;
+    }
+    return this.sessionId;
+  }
+
   private joinTagsAndMetaData(
     tags?: string[],
     metadata1?: Record<string, unknown>,
@@ -942,6 +1070,18 @@ export class OpenlayerHandler extends BaseCallbackHandler {
     if (metadata2) {
       Object.assign(finalDict, metadata2);
     }
+
+    // Attach session/user context so it propagates to the uploaded trace. The
+    // session may come from an explicit `sessionId` or be auto-mapped from
+    // LangGraph's `metadata.thread_id` (see resolveSessionId).
+    const sessionId = this.resolveSessionId(metadata1);
+    if (sessionId != null && !('session_id' in finalDict)) {
+      finalDict['session_id'] = sessionId;
+    }
+    if (this.userId != null && !('user_id' in finalDict)) {
+      finalDict['user_id'] = this.userId;
+    }
+
     return this.stripOpenlayerKeysFromMetadata(finalDict);
   }
 
@@ -959,15 +1099,11 @@ export class OpenlayerHandler extends BaseCallbackHandler {
 
   private extractUsageMetadata(generation: Generation): UsageMetadata | undefined {
     try {
-      const usageMetadata =
-        (
-          'message' in generation &&
-          (generation['message'] instanceof AIMessage || generation['message'] instanceof AIMessageChunk)
-        ) ?
-          generation['message'].usage_metadata
-        : undefined;
-
-      return usageMetadata;
+      // Detect the AI message via duck typing (presence of `usage_metadata` /
+      // `tool_calls` or a 'ai' discriminator) rather than `instanceof`, so usage
+      // is captured even across duplicate `@langchain/core` copies (OPEN-11316).
+      const message = 'message' in generation ? (generation as any)['message'] : undefined;
+      return isAIMessageLike(message) ? message.usage_metadata : undefined;
     } catch (err) {
       console.debug(`Error extracting usage metadata: ${err}`);
       return;
@@ -976,12 +1112,8 @@ export class OpenlayerHandler extends BaseCallbackHandler {
 
   private extractModelNameFromMetadata(generation: any): string | undefined {
     try {
-      return (
-          'message' in generation &&
-            (generation['message'] instanceof AIMessage || generation['message'] instanceof AIMessageChunk)
-        ) ?
-          generation['message'].response_metadata?.['model_name']
-        : undefined;
+      const message = 'message' in generation ? generation['message'] : undefined;
+      return isAIMessageLike(message) ? message.response_metadata?.['model_name'] : undefined;
     } catch {
       return undefined;
     }
@@ -990,29 +1122,34 @@ export class OpenlayerHandler extends BaseCallbackHandler {
   private extractChatMessageContent(message: BaseMessage): LlmMessage | AnonymousLlmMessage | MessageContent {
     let response: any = undefined;
 
-    if (message instanceof HumanMessage) {
+    // Duck-typed discriminator (see getMessageType) instead of `instanceof` so
+    // classification works across duplicate `@langchain/core` copies.
+    const duck = message as unknown as DuckMessage;
+    const messageType = getMessageType(duck);
+
+    if (messageType === 'human') {
       response = { content: message.content, role: 'user' };
-    } else if (message instanceof ChatMessage) {
-      response = { content: message.content, role: message.role };
-    } else if (message instanceof AIMessage) {
+    } else if (messageType === 'chat') {
+      response = { content: message.content, role: duck.role };
+    } else if (messageType === 'ai') {
       response = { content: message.content, role: 'assistant' };
 
-      if ('tool_calls' in message && (message.tool_calls?.length ?? 0) > 0) {
-        response['tool_calls'] = message['tool_calls'];
+      if ((duck.tool_calls?.length ?? 0) > 0) {
+        response['tool_calls'] = duck.tool_calls;
       }
-    } else if (message instanceof SystemMessage) {
+    } else if (messageType === 'system') {
       response = { content: message.content, role: 'system' };
-    } else if (message instanceof FunctionMessage) {
+    } else if (messageType === 'function') {
       response = {
         content: message.content,
         additional_kwargs: message.additional_kwargs,
-        role: message.name,
+        role: duck.name,
       };
-    } else if (message instanceof ToolMessage) {
+    } else if (messageType === 'tool') {
       response = {
         content: message.content,
         additional_kwargs: message.additional_kwargs,
-        role: message.name,
+        role: duck.name,
       };
     } else if (!message.name) {
       response = { content: message.content };

--- a/tests/langchain-callback.test.ts
+++ b/tests/langchain-callback.test.ts
@@ -1,0 +1,159 @@
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type { UsageMetadata } from '@langchain/core/messages';
+import type { LLMResult } from '@langchain/core/outputs';
+import type { Serialized } from '@langchain/core/load/serializable';
+import { OpenlayerHandler } from '../src/lib/integrations/langchainCallback';
+import { processAndUploadTrace, getCurrentStep } from '../src/lib/tracing/tracer';
+
+// The handler imports only these two symbols from the tracer; mock them so we
+// can capture the trace it would upload and keep the handler as the trace owner.
+jest.mock('../src/lib/tracing/tracer', () => ({
+  getCurrentStep: jest.fn(() => undefined),
+  processAndUploadTrace: jest.fn(),
+}));
+
+const uploadMock = processAndUploadTrace as jest.Mock;
+const getCurrentStepMock = getCurrentStep as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getCurrentStepMock.mockReturnValue(undefined);
+  jest.spyOn(console, 'debug').mockImplementation(() => {});
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+const llmSerialized = {
+  lc: 1,
+  type: 'constructor',
+  id: ['langchain', 'chat_models', 'openai', 'ChatOpenAI'],
+  kwargs: {},
+} as unknown as Serialized;
+
+const chainSerialized = {
+  lc: 1,
+  type: 'constructor',
+  id: ['langchain', 'chains', 'SomeChain'],
+  kwargs: {},
+} as unknown as Serialized;
+
+/** Real @langchain/core AIMessage carrying usage metadata (cast through unknown
+ * because the 1.x generic types collapse usage_metadata in fixtures). */
+function makeAIMessage(content: string, usage?: UsageMetadata, toolCalls?: unknown[]): AIMessage {
+  return new AIMessage({ content, usage_metadata: usage, tool_calls: toolCalls } as unknown as {
+    content: string;
+  });
+}
+
+function makeLLMResult(message: unknown, text = ''): LLMResult {
+  return { generations: [[{ text, message } as any]] } as LLMResult;
+}
+
+/** The trace the handler last tried to upload. */
+function lastTrace(): any {
+  return uploadMock.mock.calls.at(-1)?.[0];
+}
+
+describe('OpenlayerHandler - real @langchain/core (1.x) messages', () => {
+  it('captures role + content for chat-model-start prompts', async () => {
+    const handler = new OpenlayerHandler();
+    const runId = 'run-1';
+    await handler.handleChatModelStart(
+      llmSerialized,
+      [[new HumanMessage('Hello there')]],
+      runId,
+      undefined,
+      { invocation_params: { model: 'gpt-4o' } },
+      [],
+      { ls_provider: 'openai' },
+    );
+    await handler.handleLLMEnd(makeLLMResult(makeAIMessage('Hi!'), 'Hi!'), runId);
+
+    const prompt = lastTrace().steps[0].inputs.prompt;
+    expect(prompt[0]).toMatchObject({ role: 'user', content: 'Hello there' });
+  });
+
+  it('extracts token usage from a real AIMessage usage_metadata', async () => {
+    const handler = new OpenlayerHandler();
+    const runId = 'run-2';
+    await handler.handleChatModelStart(llmSerialized, [[new HumanMessage('q')]], runId);
+    const usage: UsageMetadata = { input_tokens: 11, output_tokens: 7, total_tokens: 18 };
+    await handler.handleLLMEnd(makeLLMResult(makeAIMessage('a', usage), 'a'), runId);
+
+    const step = lastTrace().steps[0];
+    expect(step.promptTokens).toBe(11);
+    expect(step.completionTokens).toBe(7);
+    expect(step.tokens).toBe(18);
+  });
+});
+
+describe('OpenlayerHandler - foreign core (duplicate copy) regression', () => {
+  // A message from a *different* @langchain/core copy: not an instance of the
+  // imported classes, only the duck-typed surface.
+  const foreignAI = (content: string, usage?: UsageMetadata, toolCalls?: unknown[]) => ({
+    _getType: () => 'ai',
+    getType: () => 'ai',
+    content,
+    usage_metadata: usage,
+    tool_calls: toolCalls,
+    additional_kwargs: {},
+    response_metadata: {},
+  });
+
+  it('extracts usage_metadata from a foreign-core AI message', async () => {
+    const handler = new OpenlayerHandler();
+    const runId = 'run-3';
+    await handler.handleChatModelStart(llmSerialized, [[new HumanMessage('q')]], runId);
+    await handler.handleLLMEnd(
+      makeLLMResult(foreignAI('a', { input_tokens: 3, output_tokens: 5, total_tokens: 8 }), 'a'),
+      runId,
+    );
+
+    const step = lastTrace().steps[0];
+    expect(step.tokens).toBe(8);
+    expect(step.promptTokens).toBe(3);
+  });
+
+  it('classifies a foreign-core human message by its duck-typed role', async () => {
+    const handler = new OpenlayerHandler();
+    const runId = 'run-4';
+    const foreignHuman = { _getType: () => 'human', getType: () => 'human', content: 'hey' };
+    await handler.handleChatModelStart(llmSerialized, [[foreignHuman as any]], runId);
+    await handler.handleLLMEnd(makeLLMResult(makeAIMessage('hi'), 'hi'), runId);
+
+    expect(lastTrace().steps[0].inputs.prompt[0]).toMatchObject({ role: 'user', content: 'hey' });
+  });
+});
+
+describe('OpenlayerHandler - LangGraph metadata', () => {
+  async function chainRun(
+    metadata: Record<string, unknown>,
+    params?: ConstructorParameters<typeof OpenlayerHandler>[0],
+  ) {
+    const handler = new OpenlayerHandler(params);
+    const runId = `chain-${Math.round(performance.now())}-${Object.keys(metadata).join('-')}`;
+    await handler.handleChainStart(chainSerialized, { input: 'x' }, runId, undefined, [], metadata);
+    await handler.handleChainEnd({ output: 'y' }, runId);
+    return lastTrace().steps[0];
+  }
+
+  it('names a chain step after metadata.langgraph_node', async () => {
+    const step = await chainRun({ langgraph_node: 'agent' });
+    expect(step.name).toBe('agent');
+  });
+
+  it('maps metadata.thread_id to the session id by default', async () => {
+    const step = await chainRun({ thread_id: 't-123' });
+    expect(step.metadata.session_id).toBe('t-123');
+  });
+
+  it('does not map thread_id when mapThreadIdToSession is false', async () => {
+    const step = await chainRun({ thread_id: 't-123' }, { mapThreadIdToSession: false });
+    expect(step.metadata.session_id).toBeUndefined();
+  });
+
+  it('does not clobber an explicit sessionId with thread_id', async () => {
+    const step = await chainRun({ thread_id: 't-123' }, { sessionId: 'explicit-session' });
+    expect(step.metadata.session_id).toBe('explicit-session');
+  });
+});


### PR DESCRIPTION
## Summary

Makes the LangChain callback handler work under `@langchain/core` v1 and adds LangGraph metadata mapping, for [OPEN-11316](https://linear.app/openlayer/issue/OPEN-11316).

> **Rebased onto `main` (0.28.0).** This branch was re-applied on top of the callback rewrite that landed in `main` (`11d1039` "align LangChain/LangGraph tracing with the Python SDK" + offline buffering). The changes below are now against the rewritten handler.

## `@langchain/core` v1 support
**Root cause:** the SDK pinned `@langchain/core` as a direct `^0.3.x` dependency, so an app on core v1 ends up with **two copies** of core; the handler's `instanceof` checks against *its* copy then fail for the app's message objects → content/role collapse and zero tokens, silently.
- Moved `@langchain/core`, `/community`, `/langgraph` from `dependencies` to **optional `peerDependencies`** (`@langchain/core: ">=0.3.80 <2"`), added 1.x `devDependencies`.
- Added **`@types/uuid`** to `devDependencies`: it was provided transitively by the langchain 0.3.x deps; once those move to peer deps it must be declared explicitly, or `tsc` fails with `TS7016` on the `uuid` import in `steps.ts`.
- Replaced all runtime `instanceof` against `@langchain/core` message classes with **duck typing** (`getType()`/`_getType()`, presence of `usage_metadata`/`tool_calls`); message-class imports are now `import type`.

## LangGraph metadata + serverless docs
- **`langgraph_node` step naming**: chain steps are named from `metadata.langgraph_node` when present.
- **`thread_id` → session**: auto-maps `metadata.thread_id` to the trace session when no explicit `sessionId` was given (opt-out via `mapThreadIdToSession`, default true; never clobbers an explicit `sessionId`).
- **README**: new "LangChain integration" section documenting serverless callback flushing (`await awaitAllCallbacks()` / fully awaiting `.invoke()`) and the Node 20+ requirement for core v1.

## Tests
`tests/langchain-callback.test.ts` — **8/8 passing**: real 1.x messages (role/content + token usage), a "foreign core" duplicate-copy regression case proving the duck typing works, and LangGraph metadata (node naming + `thread_id`→session incl. opt-out and no-clobber).

Verified locally: `prettier --check .`, `eslint .`, `yarn build`, `tsc --noEmit` all clean; jest green.

## Related
Promoting `session_id`/`user_id` to a first-class platform session (the tracer-side column config) is **#214 (OPEN-11322)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
